### PR TITLE
fix(tempfile): Add option to set the name of temporary files

### DIFF
--- a/pollination_handlers/inputs/ddy.py
+++ b/pollination_handlers/inputs/ddy.py
@@ -27,17 +27,17 @@ def ddy_handler(ddy_obj):
             ddy_file = ddy_obj
         elif ddy_obj.lower().endswith('.epw'):
             epw_obj = EPW(ddy_obj)
-            file_path = get_tempfile('ddy')
+            file_path = get_tempfile('ddy', epw_obj.location.city)
             ddy_file = epw_obj.to_ddy(file_path)
         else:
             raise ValueError(
                 'File path should end with ddy or epw not %s' % ddy_obj.split('.')[-1]
             )
     elif isinstance(ddy_obj, DDY):
-        ddy_file = get_tempfile('ddy')
+        ddy_file = get_tempfile('ddy', ddy_obj.location.city)
         ddy_obj.save(ddy_file)
     elif isinstance(ddy_obj, EPW):
-        file_path = get_tempfile('ddy')
+        file_path = get_tempfile('ddy', ddy_obj.location.city)
         ddy_file = ddy_obj.to_ddy(file_path)
     else:
         raise ValueError(

--- a/pollination_handlers/inputs/helper.py
+++ b/pollination_handlers/inputs/helper.py
@@ -3,9 +3,10 @@ import tempfile
 import uuid
 
 
-def get_tempfile(extension):
+def get_tempfile(extension, file_name=None):
     """Get full path to a temporary file with extension."""
-    file_name = str(uuid.uuid4())[:6]
+    file_name = str(uuid.uuid4())[:6] if file_name is None \
+        or file_name == '-' else file_name
     temp_dir = tempfile.gettempdir()
     file_path = os.path.join(temp_dir, '%s.%s' % (file_name, extension))
     return file_path

--- a/pollination_handlers/inputs/model.py
+++ b/pollination_handlers/inputs/model.py
@@ -24,10 +24,9 @@ def model_to_json(model_obj):
             raise ValueError('Invalid file path: %s' % model_obj)
         hb_file = model_obj
     elif isinstance(model_obj, Model):
-        hb_file = get_tempfile('hbjson')
-        obj_dict = model_obj.to_dict()
-
+        hb_file = get_tempfile('hbjson', model_obj.identifier)
         # write the dictionary into a file
+        obj_dict = model_obj.to_dict()
         with open(hb_file, 'w') as fp:
             json.dump(obj_dict, fp)
     else:
@@ -54,10 +53,9 @@ def model_dragonfly_to_json(model_obj):
             raise ValueError('Invalid file path: %s' % model_obj)
         df_file = model_obj
     elif isinstance(model_obj, ModelDF):
-        df_file = get_tempfile('dfjson')
-        obj_dict = model_obj.to_dict()
-
+        df_file = get_tempfile('dfjson', model_obj.identifier)
         # write the dictionary into a file
+        obj_dict = model_obj.to_dict()
         with open(df_file, 'w') as fp:
             json.dump(obj_dict, fp)
     else:

--- a/pollination_handlers/inputs/simulation.py
+++ b/pollination_handlers/inputs/simulation.py
@@ -24,9 +24,8 @@ def energy_sim_par_to_json(sim_par_obj):
             raise ValueError('Invalid file path: %s' % sim_par_obj)
         sp_file = sim_par_obj
     elif isinstance(sim_par_obj, SimulationParameter):
-        sp_file = get_tempfile('json')
+        sp_file = get_tempfile('json', 'simulation_parameter')
         obj_dict = sim_par_obj.to_dict()
-
         # write the dictionary into a file
         with open(sp_file, 'w') as fp:
             json.dump(obj_dict, fp)

--- a/pollination_handlers/inputs/wea.py
+++ b/pollination_handlers/inputs/wea.py
@@ -27,17 +27,17 @@ def wea_handler(wea_obj):
         elif wea_obj.lower().endswith('.epw'):
             # translate epw to wea
             wea = Wea.from_epw_file(wea_obj)
-            file_path = get_tempfile('wea')
+            file_path = get_tempfile('wea', wea.location.city)
             wea_file = wea.write(file_path)
         else:
             raise ValueError(
                 'File path should end with wea or epw not %s' % wea_obj.split('.')[-1]
             )
     elif isinstance(wea_obj, Wea):
-        file_path = get_tempfile('wea')
+        file_path = get_tempfile('wea', wea_obj.location.city)
         wea_file = wea_obj.write(file_path)
     elif isinstance(wea_obj, EPW):
-        file_path = get_tempfile('wea')
+        file_path = get_tempfile('wea', wea_obj.location.city)
         wea_file = wea_obj.to_wea(file_path)
     else:
         raise ValueError(


### PR DESCRIPTION
Since I have realized that we will need to copy all of the temporary files into the project folder, we really should be using nicer file names instead of uuids.  For local runs, I think this will also cut down on the amount of "garbage tempfile" space that we start to take up on people's machines, since the file will get overwritten each time a model with the same ID or a wea from the same city is written.