### PR TITLE
fix(daylight): update handlers to use full_id

### DIFF
--- a/pollination_handlers/outputs/daylight.py
+++ b/pollination_handlers/outputs/daylight.py
@@ -21,7 +21,8 @@ def read_df_from_folder(result_folder):
         grid_list = json.load(json_file)
     results = []
     for grid in grid_list:
-        result_file = os.path.join(result_folder, '{}.res'.format(grid['identifier']))
+        id_ = grid['full_id'] if 'full_id' in grid else grid['identifier']
+        result_file = os.path.join(result_folder, '{}.res'.format(id_))
         if os.path.isfile(result_file):
             with open(result_file) as inf:
                 results.append([min(float(line), 100) for line in inf])
@@ -43,7 +44,8 @@ def sort_ill_from_folder(result_folder):
         grid_list = json.load(json_file)
     results = []
     for grid in grid_list:
-        result_file = os.path.join(result_folder, '{}.ill'.format(grid['identifier']))
+        id_ = grid['full_id'] if 'full_id' in grid else grid['identifier']
+        result_file = os.path.join(result_folder, '{}.ill'.format(id_))
         if os.path.isfile(result_file):
             results.append(result_file)
     sun_up_file = os.path.join(result_folder, 'sun-up-hours.txt')


### PR DESCRIPTION
This commit adds support for models that are created with sensor-grid-groups. In that case, the results can be in a sub-folder with the group name. grid_info now provides a `full_id` key which is `identifier/group_identifier` for objects with group and stays as `identifier` for grids with no group assigned.

The change will not break the older models as it checks to see if `full_id` key is available before trying to get the value.

In hindsight I should have send this PR first before pushing the new version of the recipes! Still getting my head around what change affects what. Will do that next time.
