### PR TITLE
fix(runperiod): Remove unnecessary check of start before end

### DIFF
--- a/pollination_handlers/inputs/runperiod.py
+++ b/pollination_handlers/inputs/runperiod.py
@@ -3,15 +3,14 @@ from ladybug.analysisperiod import AnalysisPeriod
 
 
 def run_period_to_str(value):
-    """Translate an AnalysisPeriod into a string with start before end check.
+    """Translate an AnalysisPeriod into a string.
 
     Args:
         value: Either an AnalysisPeriod object or a string representation
             of an AnalysisPeriod.
 
     Returns:
-        str -- string version of the number or JSON array string of data
-            collection values.
+        str -- string version of the run period.
     """
     if value == '':
         r_per, r_per_str = AnalysisPeriod(), value
@@ -22,6 +21,4 @@ def run_period_to_str(value):
     else:
         raise ValueError('Run period must be a string or an AnalysisPeriod '
                          'object. Got {}.'.format(type(value)))
-    assert r_per.st_time < r_per.end_time, 'Run period start time must be before ' \
-        'end time. "{}" comes after "{}".'.format(r_per.st_time, r_per.end_time)
     return r_per_str

--- a/tests/input_runperiod_test.py
+++ b/tests/input_runperiod_test.py
@@ -9,5 +9,4 @@ def test_north_vector_to_angle():
     r_per_2 = AnalysisPeriod(6, 21, 0, 3, 21, 23)
 
     assert isinstance(run_period_to_str(r_per_1), str)
-    with pytest.raises(AssertionError):
-        run_period_to_str(r_per_2)
+    assert isinstance(run_period_to_str(r_per_2), str)


### PR DESCRIPTION
Now that I know EnergyPlus is fine with the reversed run periods, this check is not needed.