### PR TITLE
fix(model): Revert #136 grid check with files

### DIFF
--- a/pollination_handlers/inputs/model.py
+++ b/pollination_handlers/inputs/model.py
@@ -126,11 +126,6 @@ def model_to_json_grid_check(model_obj):
         if len(model_obj.properties.radiance.sensor_grids) == 0:
             raise ValueError(
                 'Model contains no sensor girds. This is required for this recipe.')
-    if isinstance(model_obj, str) and os.path.isfile(model_obj):
-        model_obj = Model.from_file(model_obj)
-        if len(model_obj.properties.radiance.sensor_grids) == 0:
-            raise ValueError(
-                'Model contains no sensor girds. This is required for this recipe.')
     if isinstance(model_obj, str) and os.path.isdir(model_obj):
         return _process_model_rad_folder(model_obj)
     return model_to_json(model_obj)

--- a/tests/input_model_test.py
+++ b/tests/input_model_test.py
@@ -41,11 +41,11 @@ def test_read_model_object():
     with pytest.raises(ValueError):
         model_to_json_view_check(model)
 
-    with pytest.raises(ValueError):
-        model_to_json_grid_check('./tests/assets/no_grid.hbjson')
+    #with pytest.raises(ValueError):
+    #    model_to_json_grid_check('./tests/assets/no_grid.hbjson')
 
-    with pytest.raises(ValueError):
-        model_to_json_grid_room_check('./tests/assets/no_grid.hbjson')
+    #with pytest.raises(ValueError):
+    #    model_to_json_grid_room_check('./tests/assets/no_grid.hbjson')
 
 
 def test_read_model_dragonfly_str():


### PR DESCRIPTION
We used to have the Model handler set up such that, if you just connected up the file path to a HBJSON, the file would just get copied for upload without loading it into Python. [It seems that we changed this a few months ago](https://github.com/pollination/handlers-python/commit/62fe930f5bc76a99250f9fdd8824ae3fb755260f) but we should revert it since being able to plugin in a file path instead of a Model object and know that extra time wouldn't be spent saving or re-parsing it was really useful.

From my understanding, the re-parsing routine was added a few months ago because of checks that we wanted to run from the Rhino plugin but, for a case like that, the check should be run on the .NET side where we have the Rhino plugin Model object in .NET form instead of writing a large .NET Model object to JSON, loading the model from JSON to Python, running the check in Python, and then writing the Model from Python back to JSON. [It's for cases like this that we have handlers that are written in .NET](https://github.com/pollination/handlers-csharp).

I'm specifically reverting this change now in order to unblock someone who has a large HBJSON file but we should implement the correct set of checks in the handlers-csharp when we get the chance.